### PR TITLE
refactor: relocate `EmailAuthMsg` implementations

### DIFF
--- a/packages/relayer/src/model.rs
+++ b/packages/relayer/src/model.rs
@@ -1,12 +1,10 @@
 use anyhow::{Error, Ok, Result};
 use chrono::NaiveDateTime;
-use ethers::utils::hex;
 use serde::{Deserialize, Serialize};
 use sqlx::types::Json;
 use sqlx::{FromRow, PgPool};
 use uuid::Uuid;
 
-use crate::abis::{EmailAuthMsg, EmailProof};
 use crate::schema::EmailTxAuthSchema;
 
 /// Represents a request model with details about the request status and associated email transaction authentication.
@@ -37,67 +35,6 @@ pub struct ExpectedReplyModel {
     /// The timestamp when the expected reply was created.
     #[serde(rename = "createdAt")]
     pub created_at: chrono::DateTime<chrono::Utc>,
-}
-
-impl EmailAuthMsg {
-    pub async fn save(&self, pool: &PgPool, request_id: Uuid) -> Result<()> {
-        sqlx::query!(
-            "INSERT INTO email_auth_messages (request_id, response) VALUES ($1, $2)",
-            request_id.to_string(),
-            serde_json::to_value(self)?
-        )
-        .execute(pool)
-        .await?;
-        Ok(())
-    }
-}
-
-impl Serialize for EmailAuthMsg {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-
-        let mut state = serializer.serialize_struct("EmailAuthMsg", 4)?;
-        state.serialize_field("templateId", &self.template_id)?;
-        state.serialize_field("commandParams", &self.command_params)?;
-        state.serialize_field(
-            "skippedCommandPrefix",
-            &self.skipped_command_prefix.as_u128(),
-        )?;
-        state.serialize_field("proof", &self.proof)?;
-        state.end()
-    }
-}
-
-impl Serialize for EmailProof {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-
-        let mut state = serializer.serialize_struct("EmailProof", 8)?;
-        state.serialize_field("domainName", &self.domain_name)?;
-        state.serialize_field(
-            "publicKeyHash",
-            &format!("0x{}", hex::encode(self.public_key_hash)),
-        )?;
-        state.serialize_field("timestamp", &self.timestamp.as_u64())?;
-        state.serialize_field("maskedCommand", &self.masked_command)?;
-        state.serialize_field(
-            "emailNullifier",
-            &format!("0x{}", hex::encode(self.email_nullifier)),
-        )?;
-        state.serialize_field(
-            "accountSalt",
-            &format!("0x{}", hex::encode(self.account_salt)),
-        )?;
-        state.serialize_field("isCodeExist", &self.is_code_exist)?;
-        state.serialize_field("proof", &format!("0x{}", hex::encode(&self.proof)))?;
-        state.end()
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, sqlx::Type)]


### PR DESCRIPTION
## Description
Minor refactoring. Relocated `impl` blocks for `EmailAuthMsg` to `handlers.rs` file

## Type of change
- [x] refactoring: no change in behavior 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules