### PR TITLE
Zkfriendly/zk 1053 swap modal prover in email tx builder with gpu prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,13 +1943,13 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 [[package]]
 name = "halo2curves"
 version = "0.7.0"
-source = "git+https://github.com/privacy-scaling-explorations/halo2curves.git#8771fe5a5d54fc03e74dbc8915db5dad3ab46a83"
+source = "git+https://github.com/privacy-scaling-explorations/halo2curves.git?rev=8771fe5a5d54fc03e74dbc8915db5dad3ab46a83#8771fe5a5d54fc03e74dbc8915db5dad3ab46a83"
 dependencies = [
  "blake2",
  "digest 0.10.7",
  "ff",
  "group",
- "halo2derive",
+ "halo2derive 0.1.0 (git+https://github.com/privacy-scaling-explorations/halo2curves.git?rev=8771fe5a5d54fc03e74dbc8915db5dad3ab46a83)",
  "lazy_static",
  "num-bigint",
  "num-integer",
@@ -1964,6 +1964,45 @@ dependencies = [
  "static_assertions",
  "subtle",
  "unroll",
+]
+
+[[package]]
+name = "halo2curves"
+version = "0.7.0"
+source = "git+https://github.com/privacy-scaling-explorations/halo2curves.git#8771fe5a5d54fc03e74dbc8915db5dad3ab46a83"
+dependencies = [
+ "blake2",
+ "digest 0.10.7",
+ "ff",
+ "group",
+ "halo2derive 0.1.0 (git+https://github.com/privacy-scaling-explorations/halo2curves.git)",
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "pairing",
+ "pasta_curves",
+ "paste",
+ "rand",
+ "rand_core",
+ "rayon",
+ "sha2 0.10.8",
+ "static_assertions",
+ "subtle",
+ "unroll",
+]
+
+[[package]]
+name = "halo2derive"
+version = "0.1.0"
+source = "git+https://github.com/privacy-scaling-explorations/halo2curves.git?rev=8771fe5a5d54fc03e74dbc8915db5dad3ab46a83#8771fe5a5d54fc03e74dbc8915db5dad3ab46a83"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3606,7 +3645,7 @@ version = "1.0.0"
 source = "git+https://github.com/zkemail/poseidon-rs.git#fe5ce2634c27326219d4faf75beb73b40a0beb7d"
 dependencies = [
  "getrandom",
- "halo2curves",
+ "halo2curves 0.7.0 (git+https://github.com/privacy-scaling-explorations/halo2curves.git)",
  "once_cell",
  "serde",
  "thiserror 1.0.69",
@@ -3921,15 +3960,16 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relayer-utils"
-version = "0.4.2"
-source = "git+https://github.com/zkemail/relayer-utils.git?branch=main#0663df1271beac13ec14c731ee1ce7ae4be54d16"
+version = "0.4.60"
+source = "git+https://github.com/zkemail/relayer-utils.git?branch=feat/gpu_prover#92e0db380d6340cd4b608acf5b4b87af099ef12a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cfdkim",
+ "console_error_panic_hook",
  "ethers",
  "file-rotate",
- "halo2curves",
+ "halo2curves 0.7.0 (git+https://github.com/privacy-scaling-explorations/halo2curves.git?rev=8771fe5a5d54fc03e74dbc8915db5dad3ab46a83)",
  "hex",
  "hmac-sha256",
  "itertools 0.10.5",
@@ -6342,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "zk-regex-apis"
 version = "2.3.1"
-source = "git+https://github.com/zkemail/zk-regex.git#7002a2179e076449b84e3e7e8ba94e88d0a2dc2f"
+source = "git+https://github.com/zkemail/zk-regex.git?branch=dimidumo/zk-802-consistent-casing-everywhere#5b357f2c7aa4643964534d88ebe5db3512048a71"
 dependencies = [
  "fancy-regex",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,7 +3961,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "relayer-utils"
 version = "0.4.60"
-source = "git+https://github.com/zkemail/relayer-utils.git?branch=feat/gpu_prover#92e0db380d6340cd4b608acf5b4b87af099ef12a"
+source = "git+https://github.com/zkemail/relayer-utils.git?branch=main#d5564d385783ecc63a513ba8f4a03833d31a0c55"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/packages/circuits/README.md
+++ b/packages/circuits/README.md
@@ -7,6 +7,17 @@ We provide one main circuit as follows.
 #### `email_auth.circom`
 A circuit to verify that a message in the subject is authorized by a user of an account salt, derived from an email address in the From field and a random field value called account code.
 
+The circuit has the following blueprint ID and download URLs for the proving key and witness generator:
+```json
+{
+  "blueprintId": "7f3c3bc2-7c5d-4682-8d7f-f3d2f9046722",
+  "zkeyDownloadUrl": "https://storage.googleapis.com/circom-ether-email-auth/v2.0.2-dev/circuit_zkey.zip",
+  "circuitCppDownloadUrl": "https://storage.googleapis.com/circom-ether-email-auth/v2.0.2-dev/circuit.zip"
+}
+```
+
+It takes as input the following data:
+1. a padded email header `padded_header`.
 It takes as input the following data:
 1. a padded email header `padded_header`.
 2. the bytes of the padded email header `padded_header_len`.

--- a/packages/relayer/Cargo.toml
+++ b/packages/relayer/Cargo.toml
@@ -20,7 +20,7 @@ sqlx = { version = "0.8.2", features = [
 bigdecimal = "0.3.1"
 tokio = { version = "1.40.0", features = ["full"] }
 tower-http = { version = "0.6.1", features = ["cors"] }
-relayer-utils = { git = "https://github.com/zkemail/relayer-utils.git", branch = "feat/gpu_prover" }
+relayer-utils = { git = "https://github.com/zkemail/relayer-utils.git", branch = "main" }
 slog = { version = "2.7.0", features = [
     "max_level_trace",
     "release_max_level_warn",

--- a/packages/relayer/Cargo.toml
+++ b/packages/relayer/Cargo.toml
@@ -20,7 +20,7 @@ sqlx = { version = "0.8.2", features = [
 bigdecimal = "0.3.1"
 tokio = { version = "1.40.0", features = ["full"] }
 tower-http = { version = "0.6.1", features = ["cors"] }
-relayer-utils = { git = "https://github.com/zkemail/relayer-utils.git", branch = "main" }
+relayer-utils = { git = "https://github.com/zkemail/relayer-utils.git", branch = "feat/gpu_prover" }
 slog = { version = "2.7.0", features = [
     "max_level_trace",
     "release_max_level_warn",

--- a/packages/relayer/config.example.json
+++ b/packages/relayer/config.example.json
@@ -2,8 +2,13 @@
   "port": 8000,
   "databaseUrl": "postgres://relayer:relayer_password@db:5432/relayer",
   "smtpUrl": "http://smtp_server_1:3000",
-  "proverUrl": "https://zkemail--email-auth-prover-v1-5-4-flask-app.modal.run",
-  "alchemyApiKey": "",
+  "prover": {
+    "url": "https://prover.zk.email/api/prove",
+    "apiKey": "",
+    "blueprintId": "7f3c3bc2-7c5d-4682-8d7f-f3d2f9046722",
+    "zkeyDownloadUrl": "https://storage.googleapis.com/circom-ether-email-auth/v2.0.2-dev/circuit_zkey.zip",
+    "circuitCppDownloadUrl": "https://storage.googleapis.com/circom-ether-email-auth/v2.0.2-dev/circuit.zip"
+  },
   "path": {
     "pem": "./.ic.pem",
     "emailTemplates": "./email_templates"

--- a/packages/relayer/src/config.rs
+++ b/packages/relayer/src/config.rs
@@ -14,10 +14,8 @@ pub struct Config {
     pub database_url: String,
     /// The URL for the SMTP server.
     pub smtp_url: String,
-    /// The URL for the prover service.
-    pub prover_url: String,
-    // /// The API key for Alchemy services.
-    // pub alchemy_api_key: String,
+    /// Configuration for the prover service.
+    pub prover: ProverConfig,
     /// Configuration for file paths.
     pub path: PathConfig,
     /// Configuration for ICP (Internet Computer Protocol).
@@ -57,8 +55,21 @@ pub struct ChainConfig {
     pub rpc_url: String,
     /// The chain ID for the blockchain.
     pub chain_id: u32,
-    // /// The name used for Alchemy services.
-    // pub alchemy_name: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ProverConfig {
+    /// The URL for the prover service.
+    pub url: String,
+    /// The blueprint ID for the prover.
+    pub blueprint_id: String,
+    /// The URL for downloading zkey files.
+    pub zkey_download_url: String,
+    /// The URL for downloading circuit CPP files.
+    pub circuit_cpp_download_url: String,
+    /// The API key for the prover.
+    pub api_key: String,
 }
 
 // Function to load the configuration from a JSON file

--- a/packages/relayer/src/prove.rs
+++ b/packages/relayer/src/prove.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use relayer_utils::{
-    generate_email_circuit_input, generate_proof, u256_to_bytes32, EmailCircuitParams, ParsedEmail,
-    LOG,
+    generate_email_circuit_input, generate_proof, generate_proof_gpu, u256_to_bytes32,
+    EmailCircuitParams, ParsedEmail, LOG,
 };
 use slog::info;
 
@@ -54,10 +54,14 @@ pub async fn generate_email_proof(
     .await?;
 
     // Generate the proof and public signals using the circuit input
-    let (proof, public_signals) = generate_proof(
+    let (proof, public_signals) = generate_proof_gpu(
         &circuit_input,
-        "email_auth",
-        &relayer_state.config.prover_url,
+        &relayer_state.config.prover.blueprint_id,
+        &uuid::Uuid::new_v4().to_string(),
+        &relayer_state.config.prover.zkey_download_url,
+        &relayer_state.config.prover.circuit_cpp_download_url,
+        &relayer_state.config.prover.api_key,
+        &relayer_state.config.prover.url,
     )
     .await?;
 

--- a/packages/relayer/src/prove.rs
+++ b/packages/relayer/src/prove.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use relayer_utils::{
-    generate_email_circuit_input, generate_proof, generate_proof_gpu, u256_to_bytes32,
-    EmailCircuitParams, ParsedEmail, LOG,
+    generate_email_circuit_input, generate_proof_gpu, u256_to_bytes32, EmailCircuitParams,
+    ParsedEmail, LOG,
 };
 use slog::info;
 


### PR DESCRIPTION
## Description

This PR integrates GPU-based proving API call and updates the prover configuration structure. The main changes include:

1. Updated dependencies:
   - Switched to GPU-enabled branch of relayer-utils - will switch to main branch once merged with main
  
2. Enhanced prover configuration:
   - Replaced single `prover_url` with comprehensive `ProverConfig` struct
   - Added new configuration fields for blueprint ID, zkey downloads, and API key

3. Updated proving mechanism:
   - Switched from `generate_proof` to `generate_proof_gpu`
   - Adjusted new parameter passing for GPU-based proving

4. Documentation updates:
   - Added blueprint ID and download URLs to circuits README
   - Updated configuration documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
