### PR TITLE
Remove a section which is setting missing libraries for build and test

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -249,21 +249,7 @@ Partial comment-out files can be found the following. Please uncomment them.
 Run the era-test-node forking zksync sepolia
 
 ```
-era_test_node fork https://sepolia.era.zksync.dev
-```
-
-At the first forge build, you need to detect the missing libraries.
-
-```
-forge build --zksync --zk-detect-missing-libraries
-```
-
-As you saw before, you need to deploy missing libraries.
-You can deploy them by the following command for example.
-
-```
-$ forge build --zksync --zk-detect-missing-libraries
-Missing libraries detected: src/libraries/CommandUtils.sol:CommandUtils, src/libraries/DecimalUtils.sol:DecimalUtils, src/libraries/StringUtils.sol:StringUtils
+anvil-zksync fork --fork-url mainnet
 ```
 
 Run the following command in order to deploy each missing libraries:
@@ -271,7 +257,7 @@ Run the following command in order to deploy each missing libraries:
 ```
 export PRIVATE_KEY={YOUR_PRIVATE_KEY}
 export RPC_URL=http://127.0.0.1:8011
-export CHAIN_ID=260
+export CHAIN_ID=324
 
 forge create src/libraries/DecimalUtils.sol:DecimalUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
 forge create src/libraries/CommandUtils.sol:CommandUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync --libraries src/libraries/DecimalUtils.sol:DecimalUtils:{DECIMAL_UTILS_ADDRESS_YOU_DEPLOYED}
@@ -298,7 +284,7 @@ Perhaps that is a different value in each compiler version and library addresses
 Run the following commands, you'll get the bytecode hash.
 
 ```
-forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv --fork-url http://127.0.0.1:8011
+forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 324 -vvv --fork-url http://127.0.0.1:8011
 ```
 
 And then, you should replace `{YOUR_BYTECODE_HASH}` in the .env
@@ -322,7 +308,7 @@ Even if the contract size is fine for EVM, it may exceed the bytecode size limit
 
 ```
 source .env
-forge test --match-contract "IntegrationZKSyncTest" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv --ffi
+forge test --match-contract "IntegrationZKSyncTest" --system-mode=true --zksync --gas-limit 1000000000 --chain 324 -vvv --ffi
 ```
 
 ## Deployment (For zksync sepolia)

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -230,8 +230,6 @@ yarn build
 # Install foundry-zksync, please follow this URL
 https://foundry-book.zksync.io/getting-started/installation
 
-# Install era-test-node
-https://github.com/matter-labs/era-test-node
 ```
 
 Next, you should uncomment the following lines in `foundry.toml`.
@@ -246,36 +244,6 @@ Partial comment-out files can be found the following. Please uncomment them.
 - src/utils/ZKSyncCreate2Factory.sol
 - test/helpers/DeploymentHelper.sol
 
-Run the era-test-node forking zksync sepolia
-
-```
-anvil-zksync fork --fork-url mainnet
-```
-
-Run the following command in order to deploy each missing libraries:
-
-```
-export PRIVATE_KEY={YOUR_PRIVATE_KEY}
-export RPC_URL=http://127.0.0.1:8011
-export CHAIN_ID=324
-
-forge create src/libraries/DecimalUtils.sol:DecimalUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
-forge create src/libraries/CommandUtils.sol:CommandUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync --libraries src/libraries/DecimalUtils.sol:DecimalUtils:{DECIMAL_UTILS_ADDRESS_YOU_DEPLOYED}
-forge create src/libraries/StringUtils.sol:StringUtils --private-key $PRIVATE_KEY --rpc-url $RPC_URL --chain $CHAIN_ID --zksync
-```
-
-After that, you can see the following lines in the foundry.toml. Please replace `{PROJECT_DIR}` and `{DEPLOYED_ADDRESS}`.
-Also, this lines are needed only for foundry-zksync, if you use normal foundry commands, please comment out. 
-
-
-```
-libraries = [
-    "{PROJECT_DIR}/packages/contracts/src/libraries/DecimalUtils.sol:DecimalUtils:{DEPLOYED_ADDRESS}", 
-    "{PROJECT_DIR}/packages/contracts/src/libraries/CommandUtils.sol:CommandUtils:{DEPLOYED_ADDRESS}"
-    "{PROJECT_DIR}/packages/contracts/src/libraries/StringUtils.sol:StringUtils:{DEPLOYED_ADDRESS}"
-]
-```
-
 About Create2, `L2ContractHelper.computeCreate2Address` should be used.
 `type(ERC1967Proxy).creationCode` doesn't work correctly in ZKsync.
 We need to use the bytecode hash intead of `type(ERC1967Proxy).creationCode`.
@@ -284,7 +252,7 @@ Perhaps that is a different value in each compiler version and library addresses
 Run the following commands, you'll get the bytecode hash.
 
 ```
-forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 324 -vvv --fork-url http://127.0.0.1:8011
+forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv
 ```
 
 And then, you should replace `{YOUR_BYTECODE_HASH}` in the .env
@@ -308,7 +276,7 @@ Even if the contract size is fine for EVM, it may exceed the bytecode size limit
 
 ```
 source .env
-forge test --match-contract "IntegrationZKSyncTest" --system-mode=true --zksync --gas-limit 1000000000 --chain 324 -vvv --ffi
+forge test --match-contract "IntegrationZKSyncTest" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv --ffi
 ```
 
 ## Deployment (For zksync sepolia)
@@ -338,7 +306,7 @@ libraries = [
 Run this command again, you'll get the bytecode hash.
 
 ```
-forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv --fork-url http://127.0.0.1:8011
+forge test --match-test "testComputeCreate2Address" --no-match-contract ".*Script.*" --system-mode=true --zksync --gas-limit 1000000000 --chain 300 -vvv
 ```
 
 And then, you should replace `{YOUR_BYTECODE_HASH}` in the .env

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -23,7 +23,7 @@ ast = true
 build_info = true
 extra_output = ["storageLayout"]
 
-# For missing libraries, please comment out following line and replace some placeholders if you use foundry-zksync
+# For missing libraries, please comment out following line and replace some placeholders if you deploy to zksync with foundry-zksync
 #libraries = [
 #    "{PROJECT_DIR}/packages/contracts/src/libraries/DecimalUtils.sol:DecimalUtils:{DEPLOYED_ADDRESS}",
 #    "{PROJECT_DIR}/packages/contracts/src/libraries/CommandUtils.sol:CommandUtils:{DEPLOYED_ADDRESS}",


### PR DESCRIPTION
## Description

Related issue is [here](https://github.com/matter-labs/foundry-zksync/issues/382)

This PR updates the setup documentation for the latest foundry-zksync

Before, when using foundry-zksync, it was necessary to deploy missing libraries in advance
Without this, neither unit tests nor integration tests could run

However, in the latest version, missing libraries are automatically detected and deployed
Because of this, both building and testing now work just like normal Foundry

Thus, I removed the section about setting missing libraries from the docs

However, setting missing libraries is still necessary for deployment

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules