### PR TITLE
feat: fix yarn zktest

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,7 +7,7 @@
     "test": "forge test --force --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --skip '*ZKSync*'",
     "test:script": "forge test --force --no-match-test \"testIntegration\" --skip '*ZKSync*' --match-path test/script/**/*.sol --threads 1",
     "zkbuild": "forge build --skip test --zksync",
-    "zktest": "forge test --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --system-mode=true --zksync --gas-limit 2000000000 --chain 300 --fork-url http://127.0.0.1:8011",
+    "zktest": "forge test --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --system-mode=true --zksync --gas-limit 2000000000 --chain 300",
     "lint": "solhint 'src/**/*.sol'"
   },
   "dependencies": {

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_completeRecovery.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_completeRecovery.t.sol
@@ -189,6 +189,7 @@ contract EmailAccountRecoveryZKSyncTest_completeRecovery is StructHelper {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertCompleteRecoveryRecoveryNotInProgress() public {
         skipIfNotZkSync();
 
@@ -224,6 +225,7 @@ contract EmailAccountRecoveryZKSyncTest_completeRecovery is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertCompleteRecovery() public {
         vm.warp(block.timestamp + 3 days);
 

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_handleAcceptance.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_handleAcceptance.t.sol
@@ -78,6 +78,7 @@ contract EmailAccountRecoveryZKSyncTest_handleAcceptance is StructHelper {
     // Can not test recovery in progress using handleAcceptance
     // Can not test invalid guardian using handleAcceptance
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleAcceptanceGuardianStatusMustBeRequested()
         public
     {
@@ -114,6 +115,7 @@ contract EmailAccountRecoveryZKSyncTest_handleAcceptance is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleAcceptanceInvalidTemplateIndex() public {
         skipIfNotZkSync();
 
@@ -147,6 +149,7 @@ contract EmailAccountRecoveryZKSyncTest_handleAcceptance is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleAcceptanceInvalidcommandParams() public {
         skipIfNotZkSync();
 
@@ -181,6 +184,7 @@ contract EmailAccountRecoveryZKSyncTest_handleAcceptance is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleAcceptanceInvalidWalletAddressInEmail()
         public
     {

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_handleRecovery.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_handleRecovery.t.sol
@@ -130,6 +130,7 @@ contract EmailAccountRecoveryZKSyncTest_handleRecovery is StructHelper {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleRecoveryGuardianIsNotDeployed() public {
         skipIfNotZkSync();
 
@@ -173,6 +174,7 @@ contract EmailAccountRecoveryZKSyncTest_handleRecovery is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleRecoveryInvalidTemplateId() public {
         skipIfNotZkSync();
 
@@ -214,6 +216,7 @@ contract EmailAccountRecoveryZKSyncTest_handleRecovery is StructHelper {
     // Can not test recovery in progress using handleRecovery
     // Can not test invalid guardian using handleRecovery
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleRecoveryGuardianStatusMustBeAccepted()
         public
     {
@@ -272,6 +275,7 @@ contract EmailAccountRecoveryZKSyncTest_handleRecovery is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleRecoveryInvalidTemplateIndex() public {
         skipIfNotZkSync();
 
@@ -313,6 +317,7 @@ contract EmailAccountRecoveryZKSyncTest_handleRecovery is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleRecoveryInvalidcommandParams() public {
         skipIfNotZkSync();
 
@@ -390,6 +395,7 @@ contract EmailAccountRecoveryZKSyncTest_handleRecovery is StructHelper {
     //     vm.stopPrank();
     // }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertHandleRecoveryInvalidNewSigner() public {
         skipIfNotZkSync();
 

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_rejectRecovery.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_rejectRecovery.t.sol
@@ -182,6 +182,7 @@ contract EmailAccountRecoveryZKSyncTest_rejectRecovery is StructHelper {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertRejectRecoveryRecoveryNotInProgress() public {
         skipIfNotZkSync();
 
@@ -206,6 +207,7 @@ contract EmailAccountRecoveryZKSyncTest_rejectRecovery is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertRejectRecovery() public {
         skipIfNotZkSync();
 
@@ -236,6 +238,7 @@ contract EmailAccountRecoveryZKSyncTest_rejectRecovery is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertRejectRecoveryOwnableUnauthorizedAccount() public {
         skipIfNotZkSync();
 

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_requestGuardian.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_requestGuardian.t.sol
@@ -35,6 +35,7 @@ contract EmailAccountRecoveryZKSyncTest_requestGuardian is StructHelper {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertRequestGuardianInvalidGuardian() public {
         skipIfNotZkSync();
 
@@ -51,6 +52,7 @@ contract EmailAccountRecoveryZKSyncTest_requestGuardian is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertRequestGuardianGuardianStatusMustBeNone() public {
         skipIfNotZkSync();
 

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_transfer.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_transfer.t.sol
@@ -34,6 +34,7 @@ contract EmailAccountRecoveryZKSyncTest_transfer is StructHelper {
         assertEq(receiver.balance, 1 ether);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertTransferOnlyOwner() public {
         skipIfNotZkSync();
 
@@ -56,6 +57,7 @@ contract EmailAccountRecoveryZKSyncTest_transfer is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertTransferOnlyOwnerInsufficientBalance() public {
         skipIfNotZkSync();
 

--- a/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_withdraw.t.sol
+++ b/packages/contracts/test/EmailAccountRecoveryZkSync/EmailAccountRecoveryZKSync_withdraw.t.sol
@@ -34,6 +34,7 @@ contract EmailAccountRecoveryZKSyncTest_withdraw is StructHelper {
         assertEq(deployer.balance, 1 ether);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertWithdrawOnlyOwner() public {
         skipIfNotZkSync();
 
@@ -52,6 +53,7 @@ contract EmailAccountRecoveryZKSyncTest_withdraw is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertWithdrawInsufficientBalance() public {
         skipIfNotZkSync();
 

--- a/packages/contracts/test/EmailAuth.t.sol
+++ b/packages/contracts/test/EmailAuth.t.sol
@@ -58,6 +58,7 @@ contract EmailAuthTest is StructHelper {
         assertEq(emailAuth.dkimRegistryAddr(), address(newDKIM));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertUpdateDKIMRegistryInvalidDkimRegistryAddress()
         public
     {
@@ -82,6 +83,7 @@ contract EmailAuthTest is StructHelper {
         assertEq(emailAuth.verifierAddr(), address(newVerifier));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertUpdateVerifierInvalidVerifierAddress() public {
         assertEq(emailAuth.verifierAddr(), address(verifier));
 
@@ -99,6 +101,7 @@ contract EmailAuthTest is StructHelper {
         assertEq(result, commandTemplate);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertGetCommandTemplateTemplateIdNotExists() public {
         vm.expectRevert(bytes("template id not exists"));
         emailAuth.getCommandTemplate(templateId);
@@ -118,6 +121,7 @@ contract EmailAuthTest is StructHelper {
         assertEq(result, commandTemplate);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertInsertCommandTemplateCommandTemplateIsEmpty()
         public
     {
@@ -128,6 +132,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertInsertCommandTemplateTemplateIdAlreadyExists()
         public
     {
@@ -141,6 +146,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testUpdateCommandTemplate() public {
         vm.expectRevert(bytes("template id not exists"));
         string[] memory result = emailAuth.getCommandTemplate(templateId);
@@ -162,6 +168,7 @@ contract EmailAuthTest is StructHelper {
         assertEq(result, newCommandTemplate);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertUpdateCommandTemplateCallerIsNotTheModule()
         public
     {
@@ -169,6 +176,7 @@ contract EmailAuthTest is StructHelper {
         emailAuth.updateCommandTemplate(templateId, commandTemplate);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertUpdateCommandTemplateCommandTemplateIsEmpty()
         public
     {
@@ -181,6 +189,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertUpdateCommandTemplateTemplateIdNotExists() public {
         vm.startPrank(deployer);
 
@@ -190,6 +199,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testDeleteCommandTemplate() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -208,6 +218,7 @@ contract EmailAuthTest is StructHelper {
         emailAuth.getCommandTemplate(templateId);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertDeleteCommandTemplateCallerIsNotTheModule()
         public
     {
@@ -215,6 +226,7 @@ contract EmailAuthTest is StructHelper {
         emailAuth.deleteCommandTemplate(templateId);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertDeleteCommandTemplateTemplateIdNotExists() public {
         vm.startPrank(deployer);
         vm.expectRevert(bytes("template id not exists"));
@@ -252,6 +264,7 @@ contract EmailAuthTest is StructHelper {
         assertEq(emailAuth.lastTimestamp(), emailAuthMsg.proof.timestamp);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailCallerIsNotTheModule() public {
         EmailAuthMsg memory emailAuthMsg = buildEmailAuthMsg();
 
@@ -265,6 +278,7 @@ contract EmailAuthTest is StructHelper {
         emailAuth.authEmail(emailAuthMsg);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailTemplateIdNotExists() public {
         vm.startPrank(deployer);
         EmailAuthMsg memory emailAuthMsg = buildEmailAuthMsg();
@@ -282,6 +296,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailInvalidDkimPublicKeyHash() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -301,6 +316,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailEmailNullifierAlreadyUsed() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -320,6 +336,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailInvalidAccountSalt() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -339,6 +356,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailInvalidTimestamp() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -361,6 +379,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailInvalidCommand() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -380,6 +399,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailInvalidEmailProof() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -406,6 +426,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailInvalidMaskedCommandLength() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
@@ -470,6 +491,7 @@ contract EmailAuthTest is StructHelper {
         assertEq(emailAuth.lastTimestamp(), emailAuthMsg.proof.timestamp);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertAuthEmailInvalidSizeOfTheSkippedCommandPrefix()
         public
     {
@@ -505,6 +527,7 @@ contract EmailAuthTest is StructHelper {
         vm.stopPrank();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testExpectRevertSetTimestampCheckEnabled() public {
         vm.expectRevert("only controller");
         emailAuth.setTimestampCheckEnabled(false);

--- a/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes.t.sol
@@ -9,6 +9,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         super.setUp();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix() public {
         string memory bytesStringNoHexPrefix = "509d286573e85f37b51f178c1";
 
@@ -16,6 +17,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(bytesStringNoHexPrefix);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix_EmptyString() public {
         string memory emptyString = "";
 
@@ -23,6 +25,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(emptyString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix_Zero() public {
         string memory shortBytesString = "0";
 
@@ -30,6 +33,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(shortBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_IncorrectPrefix_CapitalLetter() public {
         string
             memory invalidPrefixBytesString = "0X509d376452ba746b093a149f9d733c145539771d";
@@ -38,6 +42,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(invalidPrefixBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix_LeadingWhitespace()
         public
     {
@@ -48,6 +53,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(bytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_TrailingWhitespace()
         public
     {
@@ -58,6 +64,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(bytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_ZeroShortBytes()
         public
     {
@@ -66,6 +73,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(shortBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_TooHigh()
         public
     {
@@ -76,6 +84,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(invalidBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_TooLow() public {
         // hardcoded bytes memory value with final character removed
         string
@@ -85,6 +94,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(shortBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexChar_SingleNonHexChar()
         public
     {
@@ -95,6 +105,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(invalidContentBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexChar() public {
         string
             memory invalidBytesString = "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";

--- a/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes32.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes32.t.sol
@@ -9,6 +9,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         super.setUp();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix() public {
         string
             memory invalidPrefixHashString = "509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
@@ -17,6 +18,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidPrefixHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix_EmptyString()
         public
     {
@@ -26,6 +28,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(emptyString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix_Zero() public {
         string memory shortHashString = "0";
 
@@ -33,6 +36,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_IncorrectPrefix_CapitalLetter()
         public
     {
@@ -43,6 +47,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidPrefixHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix_LeadingWhitespace()
         public
     {
@@ -53,6 +58,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(hashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TrailingWhitespace()
         public
     {
@@ -63,6 +69,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(hashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroBytes()
         public
     {
@@ -72,6 +79,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroShortBytes()
         public
     {
@@ -81,6 +89,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooHigh()
         public
     {
@@ -93,6 +102,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_VeryLongInput()
         public
     {
@@ -103,6 +113,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(longHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooLow()
         public
     {
@@ -114,6 +125,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexChar_SingleNonHexChar()
         public
     {
@@ -124,6 +136,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidContentHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexChar() public {
         string
             memory invalidHashString = "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";

--- a/packages/contracts/test/utils/ECDSAOwnedDKIMRegistry/changeSigner.t.sol
+++ b/packages/contracts/test/utils/ECDSAOwnedDKIMRegistry/changeSigner.t.sol
@@ -29,6 +29,7 @@ contract ECDSAOwnedDKIMRegistryTest_changeSigner is Test {
         assertEq(dkim.signer(), newSigner, "Signer was not changed correctly");
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfNewSignerIsZeroAddress() public {
         address owner = dkim.owner();
         vm.startPrank(owner);
@@ -37,6 +38,7 @@ contract ECDSAOwnedDKIMRegistryTest_changeSigner is Test {
         dkim.changeSigner(address(0));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfNewSignerIsSame() public {
         address owner = dkim.owner();
         address currentSigner = dkim.signer();

--- a/packages/contracts/test/utils/ECDSAOwnedDKIMRegistry/revokeDKIMPublicKeyHash.t.sol
+++ b/packages/contracts/test/utils/ECDSAOwnedDKIMRegistry/revokeDKIMPublicKeyHash.t.sol
@@ -31,6 +31,7 @@ contract ECDSAOwnedDKIMRegistryTest_revokeDKIMPublicKeyHash is Test {
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfPublicKeyHashNotSet() public {
         // Attempt to revoke a public key hash that hasn't been set
         string memory revokeMsg = dkim.computeSignedMsg(
@@ -53,6 +54,7 @@ contract ECDSAOwnedDKIMRegistryTest_revokeDKIMPublicKeyHash is Test {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfSignerIsIncorrect() public {
         // Set a valid public key hash first
         string memory signedMsg = dkim.computeSignedMsg(
@@ -86,6 +88,7 @@ contract ECDSAOwnedDKIMRegistryTest_revokeDKIMPublicKeyHash is Test {
     }
 
     // Test invalid domain name
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfDomainNameIsInvalid() public {
         // Set a valid public key hash first
         string memory signedMsg = dkim.computeSignedMsg(
@@ -127,6 +130,7 @@ contract ECDSAOwnedDKIMRegistryTest_revokeDKIMPublicKeyHash is Test {
         );
     }
     // Test invalid public key hash
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfPublicKeyHashIsInvalid() public {
         // Set a valid public key hash first
         string memory signedMsg = dkim.computeSignedMsg(
@@ -168,6 +172,7 @@ contract ECDSAOwnedDKIMRegistryTest_revokeDKIMPublicKeyHash is Test {
         );
     }
     // Test if publicKeyHash is already revoked
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfPublicKeyHashIsAlreadyRevoked() public {
         // Set a valid public key hash first
         string memory signedMsg = dkim.computeSignedMsg(
@@ -223,6 +228,7 @@ contract ECDSAOwnedDKIMRegistryTest_revokeDKIMPublicKeyHash is Test {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfSignatureIsInvalid() public {
         // Set a valid public key hash first
         string memory signedMsg = dkim.computeSignedMsg(
@@ -252,6 +258,8 @@ contract ECDSAOwnedDKIMRegistryTest_revokeDKIMPublicKeyHash is Test {
             invalidSignature
         );
     }
+
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfDomainNameIsDifferent() public {
         // Set a valid public key hash first
         string memory signedMsg = dkim.computeSignedMsg(

--- a/packages/contracts/test/utils/ECDSAOwnedDKIMRegistry/setDKIMPublicKeyHash.t.sol
+++ b/packages/contracts/test/utils/ECDSAOwnedDKIMRegistry/setDKIMPublicKeyHash.t.sol
@@ -31,6 +31,7 @@ contract ECDSAOwnedDKIMRegistryTest_setDKIMPublicKeyHash is Test {
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfInvalidSelector() public {
         string memory invalidSelector = ""; // Example of an invalid selector (empty string)
         string memory signedMsg = dkim.computeSignedMsg(
@@ -53,6 +54,7 @@ contract ECDSAOwnedDKIMRegistryTest_setDKIMPublicKeyHash is Test {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfInvalidDomainName() public {
         string memory invalidDomainName = ""; // Example of an invalid domain name (empty string)
         string memory signedMsg = dkim.computeSignedMsg(
@@ -129,6 +131,7 @@ contract ECDSAOwnedDKIMRegistryTest_setDKIMPublicKeyHash is Test {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfInvalidPublicKeyHash() public {
         bytes32 zeroPublicKeyHash = bytes32(0);
         string memory signedMsg = dkim.computeSignedMsg(
@@ -285,6 +288,7 @@ contract ECDSAOwnedDKIMRegistryTest_setDKIMPublicKeyHash is Test {
         require(!dkim.isDKIMPublicKeyHashValid(domainName, publicKeyHash));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_RevertIfDuplicated() public {
         // vm.chainId(1);
         string memory signedMsg = dkim.computeSignedMsg(
@@ -319,6 +323,7 @@ contract ECDSAOwnedDKIMRegistryTest_setDKIMPublicKeyHash is Test {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfRevorked() public {
         // vm.chainId(1);
         string memory signedMsg = dkim.computeSignedMsg(
@@ -377,6 +382,7 @@ contract ECDSAOwnedDKIMRegistryTest_setDKIMPublicKeyHash is Test {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_Revert_IfSignatureInvalid() public {
         // vm.chainId(1);
         string memory signedMsg = dkim.computeSignedMsg(


### PR DESCRIPTION
## Description

There was a problem with the latest version of foundry in this repo
I set `default.allow_internal_expect_revert = true` in some test cases 

Also, it's no longer necessary to use a local node for unit tests with foundry-zksync, so I updated the zktest command in package.json

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules