### PR TITLE
Fix foundry and foundry zksync unit tests

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,7 +7,7 @@
     "test": "forge test --force --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --skip '*ZKSync*'",
     "test:script": "forge test --force --no-match-test \"testIntegration\" --skip '*ZKSync*' --match-path test/script/**/*.sol --threads 1",
     "zkbuild": "forge build --skip test --zksync",
-    "zktest": "forge test --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --system-mode=true --zksync --gas-limit 2000000000 --chain 300 --fork-url http://127.0.0.1:8011",
+    "zktest": "forge test --no-match-test \"testIntegration\" --no-match-contract \".*Script.*\" --system-mode=true --zksync --gas-limit 2000000000 --chain 300",
     "lint": "solhint 'src/**/*.sol'"
   },
   "dependencies": {

--- a/packages/contracts/test/EmailAuthWithUserOverrideableDkim.t.sol
+++ b/packages/contracts/test/EmailAuthWithUserOverrideableDkim.t.sol
@@ -145,7 +145,7 @@ contract EmailAuthWithUserOverrideableDkimTest is StructHelper {
         assertEq(emailAuth.lastTimestamp(), emailAuthMsg.proof.timestamp);
     }
 
-    function testFailAuthEmailBeforeEnabledWithoutUserApprove() public {
+    function testRevert_AuthEmailBeforeEnabledWithoutUserApprove() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
         EmailAuthMsg memory emailAuthMsg = buildEmailAuthMsg();
@@ -164,13 +164,8 @@ contract EmailAuthWithUserOverrideableDkimTest is StructHelper {
             deployer,
             new bytes(0)
         );
+        vm.expectRevert("invalid dkim public key hash");
         emailAuth.authEmail(emailAuthMsg);
         vm.stopPrank();
-
-        assertEq(
-            emailAuth.usedNullifiers(emailAuthMsg.proof.emailNullifier),
-            true
-        );
-        assertEq(emailAuth.lastTimestamp(), emailAuthMsg.proof.timestamp);
     }
 }

--- a/packages/contracts/test/IntegrationZKSync.t.sol
+++ b/packages/contracts/test/IntegrationZKSync.t.sol
@@ -46,8 +46,6 @@ contract IntegrationZKSyncTest is Test {
         vm.envOr("PROXY_BYTECODE_HASH", bytes32(0));
 
     function setUp() public {
-        vm.createSelectFork("http://127.0.0.1:8011");
-
         vm.startPrank(deployer);
         address signer = deployer;
 


### PR DESCRIPTION
## Description

This PR includes three main improvements:

1. Enhanced DKIM Authentication Test Clarity
   - Renamed test to better reflect its purpose
   - Implemented explicit revert checks with specific error messages
   - Removed unnecessary assertions

2. Removed Obsolete Fork URL Parameter
   - Removed unnecessary `fork-url` parameter from zktest command
   - Local node testing parameter is no longer needed

3. Simplified ZKSync Integration Tests
   - Removed `vm.createSelectFork` setup
   - Streamlined test configuration by removing unnecessary local fork creation
   
But there is one problem here.

The relayer-utils version 0.4.60 prevents running `npx ts-node scripts/gen_input.ts` successfully, which causes the contracts integration tests to fail.

I tried rewriting it using Bun, but encountered an issue related to snarkjs compatibility (see: https://github.com/oven-sh/bun/issues/14876).

However, I've successfully run the contracts integration tests (both foundry and foundry-zksync) locally using an older version of relayer-utils.

To use snarkjs with Bun, we need to resolve the compatibility issue mentioned above.

Also to make the GitHub Actions tests pass, we need to copy the `.github` directory from the main branch.

<!-- Fixes # (issue) -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules