### PR TITLE
Remove tautological `i >= 0` in DecimalUtils.sol

### DIFF
--- a/packages/contracts/src/libraries/DecimalUtils.sol
+++ b/packages/contracts/src/libraries/DecimalUtils.sol
@@ -9,7 +9,9 @@ library DecimalUtils {
     /// @notice Convert uint256 to human readable string with decimal places
     /// @param value uint256 value to convert
     /// @return string representation of value with decimal places
-    function uintToDecimalString(uint256 value) public pure returns (string memory) {
+    function uintToDecimalString(
+        uint256 value
+    ) public pure returns (string memory) {
         return uintToDecimalString(value, 18);
     }
 
@@ -17,14 +19,19 @@ library DecimalUtils {
     /// @param value uint256 value to convert
     /// @param decimal number of decimal places
     /// @return string representation of value with decimal places
-    function uintToDecimalString(uint256 value, uint decimal) public pure returns (string memory) {
+    function uintToDecimalString(
+        uint256 value,
+        uint decimal
+    ) public pure returns (string memory) {
         // Convert value to string in wei format (no decimals)
         bytes memory valueBytes = bytes(Strings.toString(value));
         uint8 valueLength = uint8(valueBytes.length);
 
         // Create result array with max length
         // If less than 18 decimals, then 2 extra for "0.", otherwise one extra for "."
-        bytes memory result = new bytes(valueLength > decimal ? valueLength + 1 : decimal + 2);
+        bytes memory result = new bytes(
+            valueLength > decimal ? valueLength + 1 : decimal + 2
+        );
         uint8 resultLength = uint8(result.length);
 
         // We will be populating result array by copying from value array from last to first index
@@ -38,7 +45,7 @@ library DecimalUtils {
         uint8 actualResultLen = 0;
 
         // In each iteration we fill one index of result array (starting from end)
-        for (uint8 i = resultLength - 1; i >= 0; i--) {
+        for (uint8 i = resultLength - 1; ; i--) {
             // Check if we have reached the index where we need to add decimal point
             if (i == resultLength - decimal - 1) {
                 // No need to add "." if there was no value in decimal places
@@ -81,4 +88,3 @@ library DecimalUtils {
         return string(compactResult);
     }
 }
-

--- a/packages/contracts/src/libraries/DecimalUtils.sol
+++ b/packages/contracts/src/libraries/DecimalUtils.sol
@@ -9,9 +9,7 @@ library DecimalUtils {
     /// @notice Convert uint256 to human readable string with decimal places
     /// @param value uint256 value to convert
     /// @return string representation of value with decimal places
-    function uintToDecimalString(
-        uint256 value
-    ) public pure returns (string memory) {
+    function uintToDecimalString(uint256 value) public pure returns (string memory) {
         return uintToDecimalString(value, 18);
     }
 
@@ -19,19 +17,14 @@ library DecimalUtils {
     /// @param value uint256 value to convert
     /// @param decimal number of decimal places
     /// @return string representation of value with decimal places
-    function uintToDecimalString(
-        uint256 value,
-        uint decimal
-    ) public pure returns (string memory) {
+    function uintToDecimalString(uint256 value, uint decimal) public pure returns (string memory) {
         // Convert value to string in wei format (no decimals)
         bytes memory valueBytes = bytes(Strings.toString(value));
         uint8 valueLength = uint8(valueBytes.length);
 
         // Create result array with max length
         // If less than 18 decimals, then 2 extra for "0.", otherwise one extra for "."
-        bytes memory result = new bytes(
-            valueLength > decimal ? valueLength + 1 : decimal + 2
-        );
+        bytes memory result = new bytes(valueLength > decimal ? valueLength + 1 : decimal + 2);
         uint8 resultLength = uint8(result.length);
 
         // We will be populating result array by copying from value array from last to first index
@@ -88,3 +81,4 @@ library DecimalUtils {
         return string(compactResult);
     }
 }
+


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Also, list any dependencies that are required for this change. -->

For context, in OpenZeppelin Community Contracts we're running Slither as part of the regular CI workflow. Currently, we're not ignoring Solidity libraries in `/lib`, so this repository is being analyzed as well with the following output:

```
INFO:Detectors:
DecimalUtils.uintToDecimalString(uint256,uint256) (lib/email-tx-builder/packages/contracts/src/libraries/DecimalUtils.sol#20-82) contains a tautology or contradiction:
	- i >= 0 (lib/email-tx-builder/packages/contracts/src/libraries/DecimalUtils.sol#41)
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#tautology-or-contradiction
```

This change should remove the detection issue for Slither.

<!-- Fixes # (issue) -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules