### PR TITLE
Feat/make lib functions internal

### DIFF
--- a/packages/contracts/src/libraries/CommandUtils.sol
+++ b/packages/contracts/src/libraries/CommandUtils.sol
@@ -9,11 +9,11 @@ import {DecimalUtils} from "./DecimalUtils.sol";
 library CommandUtils {
     bytes16 private constant LOWER_HEX_DIGITS = "0123456789abcdef";
     bytes16 private constant UPPER_HEX_DIGITS = "0123456789ABCDEF";
-    string public constant STRING_MATCHER = "{string}";
-    string public constant UINT_MATCHER = "{uint}";
-    string public constant INT_MATCHER = "{int}";
-    string public constant DECIMALS_MATCHER = "{decimals}";
-    string public constant ETH_ADDR_MATCHER = "{ethAddr}";
+    string internal constant STRING_MATCHER = "{string}";
+    string internal constant UINT_MATCHER = "{uint}";
+    string internal constant INT_MATCHER = "{int}";
+    string internal constant DECIMALS_MATCHER = "{decimals}";
+    string internal constant ETH_ADDR_MATCHER = "{ethAddr}";
 
     function addressToHexString(
         address addr,
@@ -89,7 +89,7 @@ library CommandUtils {
     /// @param data bytes to convert
     function bytesToHexString(
         bytes memory data
-    ) public pure returns (string memory) {
+    ) internal pure returns (string memory) {
         bytes memory hexChars = "0123456789abcdef";
         bytes memory hexString = new bytes(2 * data.length);
 
@@ -110,7 +110,7 @@ library CommandUtils {
         bytes[] memory commandParams,
         string[] memory template,
         uint stringCase
-    ) public pure returns (string memory expectedCommand) {
+    ) internal pure returns (string memory expectedCommand) {
         // Construct an expectedCommand from template and the values of commandParams.
         uint8 nextParamIndex = 0;
         string memory stringParam;
@@ -174,7 +174,7 @@ library CommandUtils {
     function removePrefix(
         string memory str,
         uint numBytes
-    ) external pure returns (string memory) {
+    ) internal pure returns (string memory) {
         require(
             numBytes <= bytes(str).length,
             "Invalid skipped command prefix size"

--- a/packages/contracts/src/libraries/DecimalUtils.sol
+++ b/packages/contracts/src/libraries/DecimalUtils.sol
@@ -9,7 +9,7 @@ library DecimalUtils {
     /// @notice Convert uint256 to human readable string with decimal places
     /// @param value uint256 value to convert
     /// @return string representation of value with decimal places
-    function uintToDecimalString(uint256 value) public pure returns (string memory) {
+    function uintToDecimalString(uint256 value) internal pure returns (string memory) {
         return uintToDecimalString(value, 18);
     }
 
@@ -17,7 +17,7 @@ library DecimalUtils {
     /// @param value uint256 value to convert
     /// @param decimal number of decimal places
     /// @return string representation of value with decimal places
-    function uintToDecimalString(uint256 value, uint decimal) public pure returns (string memory) {
+    function uintToDecimalString(uint256 value, uint decimal) internal pure returns (string memory) {
         // Convert value to string in wei format (no decimals)
         bytes memory valueBytes = bytes(Strings.toString(value));
         uint8 valueLength = uint8(valueBytes.length);

--- a/packages/contracts/src/libraries/StringUtils.sol
+++ b/packages/contracts/src/libraries/StringUtils.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {strings} from "solidity-stringutils/src/strings.sol";
+import {CommandUtils} from "./CommandUtils.sol";
 
 /**
  * @title StringUtils
@@ -10,6 +11,7 @@ import {strings} from "solidity-stringutils/src/strings.sol";
  */
 library StringUtils {
     using strings for *;
+    using CommandUtils for string;
 
     /**
      * @dev Converts a hexadecimal string to bytes.
@@ -17,13 +19,13 @@ library StringUtils {
      * @return bytes A bytes array representing the converted hexadecimal string.
      */
     function hexToBytes(
-        string calldata hexStr
-    ) public pure returns (bytes memory) {
+        string memory hexStr
+    ) internal pure returns (bytes memory) {
         require(
             hexStr.toSlice().startsWith("0x".toSlice()),
             "invalid hex prefix"
         );
-        string memory hexStrNoPrefix = hexStr[2:];
+        string memory hexStrNoPrefix = hexStr.removePrefix(2);
         bytes memory hexBytes = bytes(hexStrNoPrefix);
         require(
             hexBytes.length != 0 && hexBytes.length % 2 == 0,
@@ -46,8 +48,8 @@ library StringUtils {
      * @return bytes32 A bytes32 value representing the converted hexadecimal string.
      */
     function hexToBytes32(
-        string calldata hexStr
-    ) public pure returns (bytes32) {
+        string memory hexStr
+    ) internal pure returns (bytes32) {
         bytes memory result = hexToBytes(hexStr);
         require(result.length == 32, "bytes length is not 32");
         return bytes32(result);

--- a/packages/contracts/test/EmailAuthWithUserOverrideableDkim.t.sol
+++ b/packages/contracts/test/EmailAuthWithUserOverrideableDkim.t.sol
@@ -145,7 +145,7 @@ contract EmailAuthWithUserOverrideableDkimTest is StructHelper {
         assertEq(emailAuth.lastTimestamp(), emailAuthMsg.proof.timestamp);
     }
 
-    function testFailAuthEmailBeforeEnabledWithoutUserApprove() public {
+    function test_RevertWhen_AuthEmailBeforeEnabledWithoutUserApprove() public {
         vm.startPrank(deployer);
         _testInsertCommandTemplate();
         EmailAuthMsg memory emailAuthMsg = buildEmailAuthMsg();
@@ -164,13 +164,14 @@ contract EmailAuthWithUserOverrideableDkimTest is StructHelper {
             deployer,
             new bytes(0)
         );
+        vm.expectRevert("invalid dkim public key hash");
         emailAuth.authEmail(emailAuthMsg);
         vm.stopPrank();
 
         assertEq(
             emailAuth.usedNullifiers(emailAuthMsg.proof.emailNullifier),
-            true
+            false
         );
-        assertEq(emailAuth.lastTimestamp(), emailAuthMsg.proof.timestamp);
+        assertEq(emailAuth.lastTimestamp(), 0);
     }
 }

--- a/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes.t.sol
@@ -9,6 +9,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         super.setUp();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix() public {
         string memory bytesStringNoHexPrefix = "509d286573e85f37b51f178c1";
 
@@ -16,6 +17,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(bytesStringNoHexPrefix);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix_EmptyString() public {
         string memory emptyString = "";
 
@@ -23,6 +25,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(emptyString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix_Zero() public {
         string memory shortBytesString = "0";
 
@@ -30,7 +33,10 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(shortBytesString);
     }
 
-    function test_HexToBytes_RevertWhen_IncorrectPrefix_CapitalLetter() public {
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_HexToBytes_RevertWhen_InvalidHexPrefix_CapitalLetter()
+        public
+    {
         string
             memory invalidPrefixBytesString = "0X509d376452ba746b093a149f9d733c145539771d";
 
@@ -38,6 +44,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(invalidPrefixBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexPrefix_LeadingWhitespace()
         public
     {
@@ -48,6 +55,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(bytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_TrailingWhitespace()
         public
     {
@@ -58,6 +66,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(bytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_ZeroShortBytes()
         public
     {
@@ -66,6 +75,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(shortBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_TooHigh()
         public
     {
@@ -76,6 +86,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(invalidBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexStringLength_TooLow() public {
         // hardcoded bytes memory value with final character removed
         string
@@ -85,6 +96,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(shortBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexChar_SingleNonHexChar()
         public
     {
@@ -95,6 +107,7 @@ contract StringUtils_HexToBytes_Test is StructHelper {
         StringUtils.hexToBytes(invalidContentBytesString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes_RevertWhen_InvalidHexChar() public {
         string
             memory invalidBytesString = "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";

--- a/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes32.t.sol
+++ b/packages/contracts/test/libraries/StringUtils/StringUtils_hexToBytes32.t.sol
@@ -9,6 +9,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         super.setUp();
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix() public {
         string
             memory invalidPrefixHashString = "509d286573e85f37b51f178c1cf8376452ba746b093a149f9d733c145539771d";
@@ -17,6 +18,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidPrefixHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix_EmptyString()
         public
     {
@@ -26,6 +28,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(emptyString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix_Zero() public {
         string memory shortHashString = "0";
 
@@ -33,6 +36,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_IncorrectPrefix_CapitalLetter()
         public
     {
@@ -43,6 +47,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidPrefixHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexPrefix_LeadingWhitespace()
         public
     {
@@ -53,6 +58,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(hashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TrailingWhitespace()
         public
     {
@@ -63,6 +69,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(hashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroBytes()
         public
     {
@@ -72,6 +79,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_ZeroShortBytes()
         public
     {
@@ -81,6 +89,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooHigh()
         public
     {
@@ -93,6 +102,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_VeryLongInput()
         public
     {
@@ -103,6 +113,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(longHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexStringLength_TooLow()
         public
     {
@@ -114,6 +125,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(shortHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexChar_SingleNonHexChar()
         public
     {
@@ -124,6 +136,7 @@ contract StringUtils_HexToBytes32_Test is StructHelper {
         StringUtils.hexToBytes32(invalidContentHashString);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_HexToBytes32_RevertWhen_InvalidHexChar() public {
         string
             memory invalidHashString = "0x509d2865zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";


### PR DESCRIPTION
## Description
Makes all library functions internal. This means library logic will be inlined and the libraries themselves are never deployed. This avoids the need for library linking.

Fixes https://linear.app/zk-email/issue/SOL-83/make-commandutils-public-functions-internal

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

* StringUtils tests updated
* Other libraries are missing test coverage. Will be fixed in [tech debt](https://linear.app/zk-email/issue/SOL-84/add-test-coverage-for-email-tx-builder-libraries)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules