### PR TITLE
Remove ECDSAOwnedDKIMRegistry boolean equality

### DIFF
--- a/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol
+++ b/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol
@@ -68,11 +68,11 @@ contract ECDSAOwnedDKIMRegistry is
         require(bytes(domainName).length != 0, "Invalid domain name");
         require(publicKeyHash != bytes32(0), "Invalid public key hash");
         require(
-            isDKIMPublicKeyHashValid(domainName, publicKeyHash) == false,
+            !isDKIMPublicKeyHashValid(domainName, publicKeyHash),
             "publicKeyHash is already set"
         );
         require(
-            dkimRegistry.revokedDKIMPublicKeyHashes(publicKeyHash) == false,
+            !dkimRegistry.revokedDKIMPublicKeyHashes(publicKeyHash),
             "publicKeyHash is revoked"
         );
 
@@ -106,11 +106,11 @@ contract ECDSAOwnedDKIMRegistry is
         require(bytes(domainName).length != 0, "Invalid domain name");
         require(publicKeyHash != bytes32(0), "Invalid public key hash");
         require(
-            isDKIMPublicKeyHashValid(domainName, publicKeyHash) == true,
+            isDKIMPublicKeyHashValid(domainName, publicKeyHash),
             "publicKeyHash is not set"
         );
         require(
-            dkimRegistry.revokedDKIMPublicKeyHashes(publicKeyHash) == false,
+            !dkimRegistry.revokedDKIMPublicKeyHashes(publicKeyHash),
             "publicKeyHash is already revoked"
         );
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Also, list any dependencies that are required for this change. -->

Similar to #121, we're hitting some issues [OZ Community's CI](https://github.com/OpenZeppelin/openzeppelin-community-contracts/actions/runs/14395345653/job/40369941733?pr=96) and I think these are low hanging fruits too

```
ECDSAOwnedDKIMRegistry.setDKIMPublicKeyHash(string,string,bytes32,bytes) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#61-91) compares to a boolean constant:
	-require(bool,string)(isDKIMPublicKeyHashValid(domainName,publicKeyHash) == false,publicKeyHash is already set) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#70-73)
ECDSAOwnedDKIMRegistry.setDKIMPublicKeyHash(string,string,bytes32,bytes) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#61-91) compares to a boolean constant:
	-require(bool,string)(dkimRegistry.revokedDKIMPublicKeyHashes(publicKeyHash) == false,publicKeyHash is revoked) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#74-77)
ECDSAOwnedDKIMRegistry.revokeDKIMPublicKeyHash(string,string,bytes32,bytes) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#99-129) compares to a boolean constant:
	-require(bool,string)(dkimRegistry.revokedDKIMPublicKeyHashes(publicKeyHash) == false,publicKeyHash is already revoked) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#112-115)
ECDSAOwnedDKIMRegistry.revokeDKIMPublicKeyHash(string,string,bytes32,bytes) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#99-129) compares to a boolean constant:
	-require(bool,string)(isDKIMPublicKeyHashValid(domainName,publicKeyHash) == true,publicKeyHash is not set) (lib/email-tx-builder/packages/contracts/src/utils/ECDSAOwnedDKIMRegistry.sol#108-111)
```

<!-- Fixes # (issue) -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules