### PR TITLE
refactor: replace `require` with `if`

### DIFF
--- a/packages/contracts/src/utils/Verifier.sol
+++ b/packages/contracts/src/utils/Verifier.sol
@@ -42,12 +42,16 @@ contract Verifier is OwnableUpgradeable, UUPSUpgradeable, IVerifier {
             uint256[2][2] memory pB,
             uint256[2] memory pC
         ) = abi.decode(proof.proof, (uint256[2], uint256[2][2], uint256[2]));
-        require(pA[0] < q && pA[1] < q, "invalid format of pA");
-        require(
-            pB[0][0] < q && pB[0][1] < q && pB[1][0] < q && pB[1][1] < q,
-            "invalid format of pB"
-        );
-        require(pC[0] < q && pC[1] < q, "invalid format of pC");
+        if (
+            !(pA[0] < q &&
+                pA[1] < q &&
+                pB[0][0] < q &&
+                pB[0][1] < q &&
+                pB[1][0] < q &&
+                pB[1][1] < q &&
+                pC[0] < q &&
+                pC[1] < q)
+        ) return false;
         uint256[DOMAIN_FIELDS + COMMAND_FIELDS + 5] memory pubSignals;
         uint256[] memory stringFields;
         stringFields = _packBytes2Fields(bytes(proof.domainName), DOMAIN_BYTES);


### PR DESCRIPTION
## Description
This PR fixes the proof verification logic in the Verifier contract to properly return boolean values. The changes:

1. Replace `require` statements that caused reverts with proper boolean returns
2. Convert the proof format validation to return `false` for invalid proofs instead of reverting
3. Maintain the same validation checks for proof components (pA, pB, pC)

The modification ensures the function behaves as expected by returning `false` for invalid proofs rather than reverting, which is the intended behavior for this verification function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
all existing tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules